### PR TITLE
Py3 branch: Use print() function in both Python 2 and Python 3

### DIFF
--- a/sqlnet/model/modules/seq2sql_condition_predict.py
+++ b/sqlnet/model/modules/seq2sql_condition_predict.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import json
 import torch
 import torch.nn as nn
@@ -9,7 +10,7 @@ from net_utils import run_lstm
 class Seq2SQLCondPredictor(nn.Module):
     def __init__(self, N_word, N_h, N_depth, max_col_num, max_tok_num, gpu):
         super(Seq2SQLCondPredictor, self).__init__()
-        print "Seq2SQL where prediction"
+        print("Seq2SQL where prediction")
         self.N_h = N_h
         self.max_tok_num = max_tok_num
         self.max_col_num = max_col_num

--- a/sqlnet/model/sqlnet.py
+++ b/sqlnet/model/sqlnet.py
@@ -10,6 +10,11 @@ from sqlnet.model.modules.sqlnet_condition_predict import SQLNetCondPredictor
 from sqlnet.model.modules.select_number import SelNumPredictor
 from sqlnet.model.modules.where_relation import WhereRelationPredictor
 
+try:
+    unicode
+except NameError:  # Python 3
+    unicode = str
+
 
 class SQLNet(nn.Module):
     def __init__(self, word_emb, N_word, N_h=100, N_depth=2,


### PR DESCRIPTION
Here fixed on the __python3__ branch but also fixed on the __master__ branch in #5.