### PR TITLE
Update sqlnet_condition_predict.py

### DIFF
--- a/sqlnet/model/modules/sqlnet_condition_predict.py
+++ b/sqlnet/model/modules/sqlnet_condition_predict.py
@@ -160,7 +160,7 @@ class SQLNetCondPredictor(nn.Module):
             # print gt_cond
             chosen_col_gt = [[x[0] for x in one_gt_cond] for one_gt_cond in gt_cond]
 
-        e_cond_col, _ = col_name_encode(col_inp_var, col_name_len,
+        e_op_col, _ = col_name_encode(col_inp_var, col_name_len,
                 col_len, self.cond_op_name_enc)
         h_op_enc, _ = run_lstm(self.cond_op_lstm, x_emb_var, x_len)
         col_emb = []


### PR DESCRIPTION
Need to rename e_cond_col to e_op_col when predicting operator, because e_cond_col is already used when predicting columns of conditions.